### PR TITLE
Use clearTimeout instead of clearInterval

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,10 +6,10 @@ const useDate = ({ interval }: { interval?: Interval } = {}) => {
   const [date, setDate] = useState(new Date());
 
   useEffect(() => {
-    let intervalId: NodeJS.Timeout | undefined;
+    let timeoutId: NodeJS.Timeout | undefined;
 
     const bump = () => {
-      intervalId = setTimeout(() => {
+      timeoutId = setTimeout(() => {
         setDate(new Date());
         bump();
       }, nextCallback(new Date(), interval));
@@ -17,7 +17,7 @@ const useDate = ({ interval }: { interval?: Interval } = {}) => {
 
     bump();
 
-    return () => intervalId && clearInterval(intervalId);
+    return () => clearTimeout(timeoutId!);
   });
 
   return date;


### PR DESCRIPTION
The corresponding API to `setTimeout` is `clearTimeout`. It seems like some platforms (e.g. Node.js, Safari 14, etc.) will clear the timeout anyways, but it seems like some other does not (e.g. React Native)...