### PR TITLE
Update peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {},
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.6.0",

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="node" />
 /// <reference types="react" />
-/// <reference types="react-dom" />
 
 declare namespace NodeJS {
   interface ProcessEnv {


### PR DESCRIPTION
This package doesn't use `react-dom`, and it is compatible with version 17 & 18 of React.

This is needed for the latest npm to allow installing `react-use-date` together with a more recent version of React.